### PR TITLE
Fixes the composer-cli json malformat when requesting the status

### DIFF
--- a/flotta-image-builder-common-functions.sh
+++ b/flotta-image-builder-common-functions.sh
@@ -180,7 +180,7 @@ EOF
   # Save image in ISO format
   dnf install -y jq isomd5sum genisoimage
   composer-cli blueprints push $ISO_BLUEPRINT
-  BUILD_ID=$(composer-cli -j compose start-ostree --ref $REF --url http://$IMAGE_SERVER_ADDRESS/$IMAGE_NAME/repo/ edgedevice-iso edge-installer | jq '.build_id')
+  BUILD_ID=$(composer-cli -j compose start-ostree --ref $REF --url http://$IMAGE_SERVER_ADDRESS/$IMAGE_NAME/repo/ edgedevice-iso edge-installer | jq -r '.body.build_id')
   waiting_for_build_to_be_ready $BUILD_ID
 
   composer-cli compose image $BUILD_ID
@@ -226,8 +226,8 @@ waiting_for_build_to_be_ready(){
   BUILD_ID=$1
 
   echo "waiting for build $BUILD_ID to be ready..."
-  while [ $(composer-cli -j compose status  | jq -r '.[] | select( .id == '$BUILD_ID' ).status') == "RUNNING" ] ; do sleep 5 ; done
-  if [ $(composer-cli -j compose status  | jq -r '.[] | select( .id == '$BUILD_ID' ).status') != "FINISHED" ] ; then
+  while [ $(composer-cli -j compose info $BUILD_ID |jq -r '.body.queue_status') == "RUNNING" ] ; do sleep 5 ; done
+  if [ $(composer-cli -j compose info $BUILD_ID |jq -r '.body.queue_status') != "FINISHED" ] ; then
       echo "image composition failed"
       echo "check 'composer-cli compose status'"
       exit 1

--- a/r4e-image.sh
+++ b/r4e-image.sh
@@ -111,7 +111,7 @@ composer-cli blueprints push $BLUEPRINT_FILE
 
 # create image
 echo "Creating image $IMAGE_NAME"
-BUILD_ID=$(composer-cli -j compose start $IMAGE_NAME edge-commit | jq '.build_id')
+BUILD_ID=$(composer-cli -j compose start $IMAGE_NAME edge-commit | jq -r '.body.build_id')
 waiting_for_build_to_be_ready $BUILD_ID
 
 # extract image to web server folder


### PR DESCRIPTION
In the newer version of composer-cli, the json returned has changed from the previous version:

* The build_id generated when starting a build is now wrapped into a `body` element:

```json
{
  "method": "POST",
  "path": "/compose",
  "status": 200,
  "body": {
    "build_id": "b7722e5d-04e0-4c42-9e38-02dba1c233dc",
    "status": true
  }
}
```
* The `status` command generates an [invalid JSON](https://github.com/osbuild/weldr-client/issues/58):
```json
{
    "method": "GET",
    "path": "/compose/queue",
    "status": 200,
    "body": {
        "new": [],
        "run": []
    }
}
{
    "method": "GET",
    "path": "/compose/finished",
    "status": 200,
    "body": {
        "finished": [
            {
                "blueprint": "example",
                "compose_type": "edge-commit",
                "id": "745596bc-2edf-4cbc-b1df-4233b07e5e21",
                "image_size": 0,
                "job_created": 1652917383.3230004,
                "job_finished": 1652918103.186391,
                "job_started": 1652917733.2645538,
                "queue_status": "FINISHED",
                "version": "0.0.1"
            }
        ]
    }
}
{
    "method": "GET",
    "path": "/compose/failed",
    "status": 200,
    "body": {
        "failed": []
    }
}
```

To correct the issue, we retrieve the status from the info command:

```bash
$> composer-cli -j compose info $BUILD_ID
```
which returns a myriad of information, but the interesting one is in `.body.queue_status`.
```json
{
    "method": "GET",
    "path": "/compose/info/b7722e5d-04e0-4c42-9e38-02dba1c233dc",
    "status": 200,
    "body": {
        "blueprint": {
            "description": "RHEL edge commit",
            "distro": "",
            "groups": [],
            "modules": [],
            "name": "flotta-edge",
            "packages": [],
            "version": "0.0.1"
        },
        "commit": "",
        "compose_type": "edge-commit",
        "config": "",
        "deps": {
            "packages": [
                {
                    "arch": "x86_64",
                    "check_gpg": true,
                    "checksum": "sha256:ccbb074d1dff5da8075920bd374d86629a2a9ef7ad0fe4b0a83d5757f158de53",
                    "epoch": 0,
                    "name": "ModemManager",
                    "release": "1.el8",
                    "remote_location": "https://cdn.redhat.com/content/dist/rhel8/8.6/x86_64/baseos/os/Packages/m/ModemManager-1.18.2-1.el8.x86_64.rpm",
                    "secrets": "org.osbuild.rhsm",
                    "version": "1.18.2"
                }
           ]
        },
        "id": "b7722e5d-04e0-4c42-9e38-02dba1c233dc",
        "image_size": 0,
        "queue_status": "RUNNING"
    }
}

```



The fix in this case is to pass the correct path in the structure to `jq`. 